### PR TITLE
Fix Momentum/Xtreme compiler macros

### DIFF
--- a/fap/views/camera_suite_view_camera.h
+++ b/fap/views/camera_suite_view_camera.h
@@ -17,15 +17,16 @@
 
 #include "../helpers/camera_suite_custom_event.h"
 
-#ifdef xtreme_settings
+#ifdef FW_ORIGIN_Xtreme
 /**
  * Enable the following line for "Xtreme Firmware" & "Xtreme Apps" (Flipper-XFW).
  * 
  * @see https://github.com/Flipper-XFW/Xtreme-Firmware
  * @see https://github.com/Flipper-XFW/Xtreme-Apps
 */
+#include <xtreme/xtreme.h>
 #define UART_CH (xtreme_settings.uart_esp_channel)
-#elif defined momentum_settings
+#elif defined FW_ORIGIN_Momentum
 /**
  * Enable the following line for "Momentum Firmware" & "Momentum Apps".
  * 


### PR DESCRIPTION
- `momentum_settings` and `xtreme_settings` are available only after `#include`ing them
- Can check `FW_ORIGIN_xyz` instead
- Also missed the import on XFW side

Thank you for adding the checks in the first place tho! <3